### PR TITLE
add: docker-compose for test env && use it with jest for e2e test && script to manage test:db

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,35 @@
+PORT=3333
+
+# Jwt
+JWT_SECRET_KEY=your-secret-key
+JWT_EXPIRATION_TIME=900
+JWT_EXPIRATION_LONG_TIME=180000
+
+#OTP
+OTP_SECRET=your-secret-key
+OTP_DURATION_IN_SECS=300
+
+
+# Postgres envioroment variables
+
+# Nest run in docker, change host to database container name
+# DB_HOST=postgres
+DB_HOST=localhost
+DB_PORT=5433
+DB_USERNAME=postgres
+DB_PASSWORD=1234
+DB_NAME=test
+
+# Prisma database connection
+DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=public
+
+# REDIS envioroment variables
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+#Mailing Service
+EMAIL_HOST=
+SMTP_PORT=
+EMAIL_ADDRESS=
+EMAIL_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
 - [x] Added Bull for Queuing purpose (currently using for Queuing Emails)
 - [x] Replace Sqlite db with Prisma/Postgres
 - [x] Linter (tslint + eslint + prettier)
-- [ ] Integration Testing / Unit Testing using Jest
+- [x] Integration Testing / Unit Testing using Jest [With Test DB Environment]
 
 ## Description
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
 ## Requirements
+
 - PostgreSQL
 - Redis
 - Nodejs 18 and above

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  test_db:
+    image: postgres:14
+    restart: always
+    container_name: 'test_db'
+    environment:
+      POSTGRES_PASSWORD: '1234'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_DB: 'test'
+    ports:
+      - 5433:5432
+    networks:
+      - test
+  test_redis:
+    container_name: test_redis
+    image: redis:6.2.12 
+    restart: always
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy noeviction
+    ports:
+      - 6378:6379
+    networks:
+      - test
+
+networks:
+  test: 
+    driver: bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
+        "dotenv-cli": "^7.3.0",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -6224,6 +6225,33 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.3.0.tgz",
+      "integrity": "sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:db:up": "docker compose -f docker-compose-test.yaml up -d",
+    "test:db:rm": "docker compose -f docker-compose-test.yaml rm -sfv",
+    "test:db:rebuild": "npm run test:db:rm && npm run test:db:up && sleep 2; dotenv -e .env.test -- npm run migrate:dev",
+    "test:test": "dotenv -e .env.test -- npm run migrate:dev",
+    "test:e2e": "dotenv -e .env.test -- jest --config ./test/jest-e2e.json"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
@@ -72,6 +76,7 @@
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
+    "dotenv-cli": "^7.3.0",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,10 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "../src",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": "ts-jest",
+    "^.+\\.(ts|tsx)$": "ts-jest"
   }
 }


### PR DESCRIPTION
**Jest Configuration**

1. Added new `.env.test` which holds all the ENVs for Test Environment.
2. Added `dotenv-cli` package as a depDependencies as it is used in script to supply `.env.test` file as env for Test Environment.
3. Added `docker-compose-test.yaml` which creates `test_db` and `test_redis` container necessary for Test Environment.
4. Making different **env** files for test will avoid conflict between used **.env** file in **local** and **production** server.
5. Edited Jest Configuration to read `src` folder as rootDIr for Test Environment.